### PR TITLE
简单修复下shadowsocks Android版传入参数=变成\=而无效的问题，其它的同理。

### DIFF
--- a/cmd/gost/main.go
+++ b/cmd/gost/main.go
@@ -35,7 +35,7 @@ func init() {
 	pluginOptions = strings.ReplaceAll(pluginOptions, "#SS_HOST", os.Getenv("SS_REMOTE_HOST"))
 	pluginOptions = strings.ReplaceAll(pluginOptions, "#SS_PORT", os.Getenv("SS_REMOTE_PORT"))
 
-	//简单修复下=变成\=的问题，其它的同理。
+	//简单修复下shadowsocks Android版传入参数=变成\=而无效的问题，其它的同理。
 	pluginOptions = strings.ReplaceAll(pluginOptions, "\\=", "=")
 
 	os.Args = append(os.Args, "-L")

--- a/cmd/gost/main.go
+++ b/cmd/gost/main.go
@@ -35,6 +35,9 @@ func init() {
 	pluginOptions = strings.ReplaceAll(pluginOptions, "#SS_HOST", os.Getenv("SS_REMOTE_HOST"))
 	pluginOptions = strings.ReplaceAll(pluginOptions, "#SS_PORT", os.Getenv("SS_REMOTE_PORT"))
 
+	//简单修复下=变成\=的问题
+	pluginOptions = strings.ReplaceAll(pluginOptions, "\=", "=")
+
 	os.Args = append(os.Args, "-L")
 	os.Args = append(os.Args, fmt.Sprintf("ss+tcp://rc4-md5:gost@[%s]:%s", localHost, localPort))
 	os.Args = append(os.Args, strings.Split(pluginOptions, " ")...)

--- a/cmd/gost/main.go
+++ b/cmd/gost/main.go
@@ -36,7 +36,7 @@ func init() {
 	pluginOptions = strings.ReplaceAll(pluginOptions, "#SS_PORT", os.Getenv("SS_REMOTE_PORT"))
 
 	//简单修复下=变成\=的问题，其它的同理。
-	pluginOptions = strings.ReplaceAll(pluginOptions, "\=", "=")
+	pluginOptions = strings.ReplaceAll(pluginOptions, "\\=", "=")
 
 	os.Args = append(os.Args, "-L")
 	os.Args = append(os.Args, fmt.Sprintf("ss+tcp://rc4-md5:gost@[%s]:%s", localHost, localPort))

--- a/cmd/gost/main.go
+++ b/cmd/gost/main.go
@@ -35,7 +35,7 @@ func init() {
 	pluginOptions = strings.ReplaceAll(pluginOptions, "#SS_HOST", os.Getenv("SS_REMOTE_HOST"))
 	pluginOptions = strings.ReplaceAll(pluginOptions, "#SS_PORT", os.Getenv("SS_REMOTE_PORT"))
 
-	//简单修复下=变成\=的问题
+	//简单修复下=变成\=的问题，其它的同理。
 	pluginOptions = strings.ReplaceAll(pluginOptions, "\=", "=")
 
 	os.Args = append(os.Args, "-L")


### PR DESCRIPTION
简单修复下shadowsocks Android版传入参数=变成\=而无效的问题，其它的同理。(注:只修复了无效问题。)。